### PR TITLE
fixing typo

### DIFF
--- a/functions/schemas/header.js
+++ b/functions/schemas/header.js
@@ -1,6 +1,6 @@
 export default {
     name: 'header',
-    type: 'Document',
+    type: 'document',
       title: 'Site header',
     fields: [
       {


### PR DESCRIPTION
document must be lowercase, or else sanity will complain (and not run)